### PR TITLE
Support for ShapeDiver

### DIFF
--- a/BitmapPlus/BitmapPlus.csproj
+++ b/BitmapPlus/BitmapPlus.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Components\Visualize\GH_Bmp_PreviewImage.cs" />
     <Compile Include="Extensions\BmpExtensions.cs" />
     <Compile Include="Extensions\FilterExtensions.cs" />
+    <Compile Include="Utilities\BitmapPlusEnvironment.cs" />
     <Compile Include="Extensions\GhExtensions.cs" />
     <Compile Include="Extensions\LayerExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/BitmapPlus/Components/Files/GH_Bmp_OpenBitmap.cs
+++ b/BitmapPlus/Components/Files/GH_Bmp_OpenBitmap.cs
@@ -48,6 +48,12 @@ namespace BitmapPlus.Components
             bool load = false;
             if (!DA.GetData(1, ref load)) return;
 
+            if (BitmapPlusEnvironment.FileIoBlocked)
+            {
+                this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Reading images from files is blocked on this computer.");
+                return;
+            }
+
             if (!File.Exists(P))
             {
                 this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "The file provided path does not exist. Please verify this is a valid file path.");

--- a/BitmapPlus/Extensions/GhExtensions.cs
+++ b/BitmapPlus/Extensions/GhExtensions.cs
@@ -44,7 +44,7 @@ namespace BitmapPlus
                 image = new Img(bitmap);
                 return true;
             }
-            else if (File.Exists(filePath))
+            else if (!BitmapPlusEnvironment.FileIoBlocked && File.Exists(filePath))
             {
                 if(filePath.GetBitmapFromFile(out bitmap))
                 {

--- a/BitmapPlus/Utilities/BitmapPlusEnvironment.cs
+++ b/BitmapPlus/Utilities/BitmapPlusEnvironment.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace BitmapPlus
+{
+    public static class BitmapPlusEnvironment
+    {
+        static bool? _FileIoBlocked = null;
+
+        public static bool FileIoBlocked
+        {
+            get
+            {
+                if (_FileIoBlocked == null)
+                {
+                    var value = Environment.GetEnvironmentVariable("BLOCK_FILEIO");
+                    _FileIoBlocked = !String.IsNullOrEmpty(value);
+                }
+                return _FileIoBlocked == true;
+            }
+        }
+      
+
+    }
+}


### PR DESCRIPTION
@interopxyz I implemented `IGH_Goo` for the `Img` type and tested interoperability with ShapeDiver's bitmap type, works great now!

The second commit adds a possibility to block file IO: 
<img width="586" alt="image" src="https://github.com/interopxyz/BitmapPlus/assets/8183687/ed38efa6-8c7b-4772-878d-c18abd7e5796">
