### PR TITLE
return flattened image when casting

### DIFF
--- a/BitmapPlus/Classes/Image.cs
+++ b/BitmapPlus/Classes/Image.cs
@@ -355,12 +355,12 @@ namespace BitmapPlus
 
             if (typeof(T).IsAssignableFrom(typeof(Bitmap)))
             {
-                target = (T)((object)bitmap);
+                target = (T)((object)this.GetFlatBitmap());
                 return true;
             }
             else if (typeof(T).IsAssignableFrom(typeof(Image)))
             {
-                target = (T)((object)bitmap);
+                target = (T)((object)this.GetFlatBitmap());
                 return true;
             }
 


### PR DESCRIPTION
@interopxyz when testing we noticed a small problem, which I fixed in this PR. Could you publish a new version please (not urgent)? Sorry for the inconvenience.